### PR TITLE
Add event handler extraction support to rive code generator

### DIFF
--- a/templates/json_template.mustache
+++ b/templates/json_template.mustache
@@ -47,6 +47,11 @@
                   "defaultValue": "{{input_default_value}}"
                 }{{^last}},{{/last}}
                 {{/inputs}}
+              },
+              "events": {
+                {{#events}}
+                "{{event_camel_case}}": "{{event_name}}"{{^last}},{{/last}}
+                {{/events}}
               }
             }{{^last}},{{/last}}
             {{/state_machines}}


### PR DESCRIPTION
I had claude code write this, but tested the result on all of our Rive files.  Please have a look and see if you'd like to include it.

This enhancement enables the rive code generator to extract event handlers from state machines, addressing a limitation where only inputs were extracted but events that could be fired back to the host application were missing.

## Changes Made

### C++ Code Generator (src/main.cpp):
- Added headers for event system: rive/event.hpp, rive/animation/listener_fire_event.hpp
- Added EventInfo struct to hold event information
- Added state_machine_events field to ArtboardData struct
- Implemented get_state_machine_events_from_artboard() function that:
  - Iterates through state machine listeners
  - Checks for ListenerFireEvent actions
  - Resolves event IDs to Event objects
  - Extracts unique event names per state machine
- Integrated event extraction into template generation logic

### JSON Template (templates/json_template.mustache):
- Added "events" section within each state machine
- Events are formatted as key-value pairs: "eventCamelCase": "eventName"
- Maintains backward compatibility with existing JSON structure

## API Usage

The implementation uses the correct Rive API pattern:
1. StateMachine->listener(i) to access listeners
2. ListenerAction->is<ListenerFireEvent>() to check action type
3. ListenerFireEvent->eventId() to get event ID
4. ArtboardInstance->resolve(eventId) to get Event object
5. Event->name() to extract event name

## Example Output

Before (only inputs):
```json
"stateMachines": {
  "monsterV1": {
    "inputs": { ... }
  }
}
```

After (inputs + events):
```json
"stateMachines": {
  "monsterV1": {
    "inputs": { ... },
    "events": {
      "monstertapped": "monsterTapped",
      "enteropenmouth": "enterOpenMouth",
      "exitopenmouth": "exitOpenMouth"
    }
  }
}
```

## Testing

Tested with multiple .riv files including complex state machines with events. The enhancement correctly extracts events while maintaining all existing functionality for inputs, animations, and other data.

Resolves the limitation where event handlers like "monsterTapped" were present in Rive files but not accessible in generated code.